### PR TITLE
[UPDATE]--폰트 import url 적용(임시)

### DIFF
--- a/src/assets/styles/base/_reset.scss
+++ b/src/assets/styles/base/_reset.scss
@@ -1,45 +1,45 @@
 // Noto Sans CJK KR
 //
 // https://www.google.com/get/noto/#/family/noto-sans-kore
-@include font-face(
-  $font-family-NotoSansCJKKr,
-  $font-family-NotoSansCJKKr-DemiLight-src,
-  $font-weight-demilight,
-  normal,
-  otf
-);
+// @include font-face(
+//   $font-family-NotoSansCJKKr,
+//   $font-family-NotoSansCJKKr-DemiLight-src,
+//   $font-weight-demilight,
+//   normal,
+//   otf
+// );
 
-@include font-face(
-  $font-family-NotoSansCJKKr,
-  $font-family-NotoSansCJKKr-Regular-src,
-  $font-weight-normal,
-  normal,
-  otf
-);
+// @include font-face(
+//   $font-family-NotoSansCJKKr,
+//   $font-family-NotoSansCJKKr-Regular-src,
+//   $font-weight-normal,
+//   normal,
+//   otf
+// );
 
-@include font-face(
-  $font-family-NotoSansCJKKr,
-  $font-family-NotoSansCJKKr-Medium-src,
-  $font-weight-medium,
-  normal,
-  otf
-);
+// @include font-face(
+//   $font-family-NotoSansCJKKr,
+//   $font-family-NotoSansCJKKr-Medium-src,
+//   $font-weight-medium,
+//   normal,
+//   otf
+// );
 
-@include font-face(
-  $font-family-NotoSansCJKKr,
-  $font-family-NotoSansCJKKr-Bold-src,
-  $font-weight-bold,
-  normal,
-  otf
-);
+// @include font-face(
+//   $font-family-NotoSansCJKKr,
+//   $font-family-NotoSansCJKKr-Bold-src,
+//   $font-weight-bold,
+//   normal,
+//   otf
+// );
 
-@include font-face(
-  $font-family-D2Coding,
-  $font-family-D2Coding-Bold-src,
-  $font-weight-bold,
-  normal,
-  ttf
-);
+// @include font-face(
+//   $font-family-D2Coding,
+//   $font-family-D2Coding-Bold-src,
+//   $font-weight-bold,
+//   normal,
+//   ttf
+// );
 
 *,
 *:after,
@@ -155,8 +155,9 @@ section {
 body {
   overflow: hidden;
   line-height: 1.2;
-  font-family: $font-family-NotoSansCJKKr;
-  font-weight: $font-weight-normal;
+  font-family: 'Noto Sans KR', '맑은 고딕', 'Malgun Gothic', 'Apple Gothic', sans-serif;
+  // font-family: $font-family-NotoSansCJKKr;
+  // font-weight: $font-weight-normal;
   -webkit-font-smoothing: antialiased; 
   -webkit-text-size-adjust: 100%; //fix for iOS
   letter-spacing: -0.015em;
@@ -202,8 +203,9 @@ input,
 textarea,
 button,
 select {
-  font-family: $font-family-NotoSansCJKKr;
-  font-weight: $font-weight-normal;
+  font-family: 'Noto Sans KR', '맑은 고딕', 'Malgun Gothic', 'Apple Gothic', sans-serif;
+  // font-family: $font-family-NotoSansCJKKr;
+  // font-weight: $font-weight-normal;
   font-size: inherit;
   color: inherit;
   -webkit-appearance: none;

--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -1,5 +1,6 @@
 @charset 'utf-8';
 
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap');
 @import 'utils/variables';
 @import 'utils/mixins';
 

--- a/src/assets/styles/utils/variables/_font.scss
+++ b/src/assets/styles/utils/variables/_font.scss
@@ -2,11 +2,11 @@
 
 // Typography variables
 // --------------------------------------------------
-$font-family-NotoSansCJKKr: 'NotoSansCJKkr' !default;
-$font-family-NotoSansCJKKr-DemiLight-src: '~~@/assets/fonts/NotoSansCJKkr-DemiLight' !default;
-$font-family-NotoSansCJKKr-Regular-src: '~~@/assets/fonts/NotoSansCJKkr-Regular' !default;
-$font-family-NotoSansCJKKr-Medium-src: '~~@/assets/fonts/NotoSansCJKkr-Medium' !default;
-$font-family-NotoSansCJKKr-Bold-src: '~~@/assets/fonts/NotoSansCJKkr-Bold' !default;
+// $font-family-NotoSansCJKKr: 'NotoSansCJKkr' !default;
+// $font-family-NotoSansCJKKr-DemiLight-src: '~~@/assets/fonts/NotoSansCJKkr-DemiLight' !default;
+// $font-family-NotoSansCJKKr-Regular-src: '~~@/assets/fonts/NotoSansCJKkr-Regular' !default;
+// $font-family-NotoSansCJKKr-Medium-src: '~~@/assets/fonts/NotoSansCJKkr-Medium' !default;
+// $font-family-NotoSansCJKKr-Bold-src: '~~@/assets/fonts/NotoSansCJKkr-Bold' !default;
 
 $font-family-D2Coding: 'D2Coding' !default;
 $font-family-D2Coding-src: '~~@/assets/fonts/D2Coding' !default;


### PR DESCRIPTION
### 이슈
- 웹폰트 용량 문제로 렌더링 속도 저하 이슈 발생

### 작업
- URL import하여 임시 작업
- font-family 선언 순서로 'Noto Sans' 불러오지 않을 시, 다른 로컬 폰트 적용

### TODO
- 근본적인 해결 및 최적화 필요 
- 참고: https://velog.io/@vnthf/웹폰트-최적화-하기